### PR TITLE
Add extra check to file exists validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+.idea/
 log/*.log
 pkg/
 spec/dummy/log/*.log

--- a/app/src/frefnet/file_exists_validator.rb
+++ b/app/src/frefnet/file_exists_validator.rb
@@ -31,7 +31,7 @@ module Frefnet
 
     def frefnet_ids_to_check
       @form.attributes.map do |key, value|
-        next unless key.to_s.include?('frefnet')
+        next unless key.to_s.include?('frefnet') || key.to_s.include?('file_reference')
         value
       end
     end


### PR DESCRIPTION
* The validator was only checking keys that had the word 'frefnet'
  in them which caused some columns to skip the validation. The
  validator now checks columns with 'fil_reference' in the name