### PR TITLE
encode file name in content disposition

### DIFF
--- a/app/src/frefnet/download_link_retriever.rb
+++ b/app/src/frefnet/download_link_retriever.rb
@@ -30,7 +30,7 @@ module Frefnet
     end
 
     def content_disposition
-      "#{@content_disposition}; filename=\"#{file.original_filename}\""
+      "#{@content_disposition}; filename=\"#{ERB::Util.url_encode(file.original_filename)}\""
     end
   end
 end


### PR DESCRIPTION
encode filename for AWS error in content_disposition "header value cannot be represented using iso-8859-1"